### PR TITLE
Support RMATE_{HOST,PORT} variables.

### DIFF
--- a/rmate.sh
+++ b/rmate.sh
@@ -31,8 +31,8 @@
 hostname=`hostname`
 filepath=""
 
-host="localhost"
-port=52698
+host="${RMATE_HOST:-localhost}"
+port="${RMATE_PORT:-52698}"
 verbose=false
 nowait=true
 force=false


### PR DESCRIPTION
These specify the default host and port that rmate should connect to. This not only makes it easy to configure default values but is (AFAIK) the only way to have multiple machines connect to the same shell account and each get their own unique port (by forwarding the variables from the client to the server).

The last bits of this blog post explains the ssh variable forwarding: http://blog.macromates.com/2011/mate-and-rmate/
