### PR TITLE
fixed: file perms and ownership nuked on save

### DIFF
--- a/rmate.sh
+++ b/rmate.sh
@@ -152,7 +152,8 @@ function handle_connection {
         elif [[ "$cmd" = "save" ]]; then
             log "Saving $token"
 
-            mv "$tmp" "$token"
+            cat "$tmp" >  "$token"
+            rm "$tmp"		
         fi
     done
     


### PR DESCRIPTION
Hi,

Firstly thanks for writing rmate.sh, works great.  However I noticed an issue where a file that I was editing would have its perms set from 775 to 644 on save.

I’ve written a tiny fix for this.  It seems to work fine and preserves the ownership and perms of the files that I edit.
