### PR TITLE
Fix file truncation on save.

### DIFF
--- a/rmate
+++ b/rmate
@@ -140,7 +140,7 @@ function handle_connection {
                         touch "$tmp"
                     fi
                 
-                    dd bs=$value count=1 <&3 >>"$tmp" 2>/dev/null
+                    head -c$value <&3 >>"$tmp" 2>/dev/null
                     ;;
                 *)
                     ;;


### PR DESCRIPTION
dd issues one call to read() per block, so using a large blocksize with
a count of 1 means it only calls read() once. Bash's tcp redirection
doesn't always seem to return a full buffer in this case (often
stopping at 32KB), which results in files being truncated.

Avoid this by using head -c. head will use a sensible buffer size
automatically and continue to call read() until exactly the number of
bytes requested have been read. This fixes issue #5.
