### PR TITLE
Close stdin/out/err before forking.

### DIFF
--- a/rmate
+++ b/rmate
@@ -221,6 +221,7 @@ echo 1>&3
 echo "." 1>&3
 
 if [[ $nowait = true ]]; then
+    exec </dev/null >/dev/null 2>/dev/null
     ( (handle_connection &) &)
 else
     handle_connection


### PR DESCRIPTION
This ensures that if the parent shell exits, the tty can be closed (e.g.
when running in screen the window will close automatically instead of
waiting for all forked rmate processes to exit).
