### PR TITLE
Fix rmate editing of symlinks

### DIFF
--- a/rmate
+++ b/rmate
@@ -255,7 +255,7 @@ if [ "$filetype" != "" ]; then
 fi
 
 if [ -f "$filepath" ]; then
-    filesize=`ls -l "$filepath" | awk '{print $5}'`
+    filesize=`ls -lL "$filepath" | awk '{print $5}'`
     echo "data: $filesize" 1>&3
     cat "$filepath" 1>&3
 else


### PR DESCRIPTION
Quick fix to get the size of the target not the size of the symlink. Tested on Ubuntu 12.04, seems to be a well supported ls flag. OS X ( [man ls](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/ls.1.html) ), OpenSolaris ( [man ls](http://www.unix.com/man-page/opensolaris/1/ls/) ) and FreeBSD ( [man ls](http://www.freebsd.org/cgi/man.cgi?query=ls))
