### PR TITLE
Bugfix: host_pattern and port_pattern are flipped

### DIFF
--- a/rmate
+++ b/rmate
@@ -59,8 +59,8 @@ function load_config {
     local rc_file=$1
     local row
     
-    local host_pattern="^port:[[:space:]]+([0-9]+)"
-    local port_pattern="^host:[[:space:]]+([^ ]+)"
+    local host_pattern="^host:[[:space:]]+([^ ]+)"
+    local port_pattern="^port:[[:space:]]+([0-9]+)"
     
     if [ -f "$rc_file" ]; then
         while read row; do


### PR DESCRIPTION
Previously, when I was going to create a config file which contains host and port, rmate always said "connection failure". But manually specifying the port number like `-p 12345` worked for me. So I looked into the source code, and found the host_pattern and port_pattern flipped.
After flipping them back, everything just works.
