### PR TITLE
Allow rmate to be renamed with consistent configuration based on basename.

### DIFF
--- a/rmate
+++ b/rmate
@@ -73,7 +73,7 @@ function load_config {
     fi
 }
 
-for i in "/etc/$(basename $0).rc" "~/.$(basename $0).rc"; do
+for i in "/etc/${0##*/}" "~/.${0##*/}.rc"; do
     load_config $i
 done
 


### PR DESCRIPTION
Changed loading of configuration based on basename. This way the configuration ciles will be loaded according to the name, the script is named (i.e. no longer hard coded; assume rmate is named suhl -> load /etc/subl.rc and ~/.subl.rc).
