### PR TITLE
Fix rmate not working on files owned by user/group names with spaces

### DIFF
--- a/rmate
+++ b/rmate
@@ -325,7 +325,7 @@ if [ "$filetype" != "" ]; then
 fi
 
 if [ "$filepath" != "-" ] && [ -f "$filepath" ]; then
-    filesize=`ls -lL "$realpath" | awk '{print $5}'`
+    filesize=`ls -lLn "$realpath" | awk '{print $5}'`
     echo "data: $filesize" 1>&3
     cat "$realpath" 1>&3
 elif [ "$filepath" = "-" ]; then


### PR DESCRIPTION
Pass '-n' to ls so that UIDs/GIDs are displayed numerically, so that any
spaces embedded in user or group names don't through off the field numbers
when extracting the file size via awk.
