### PR TITLE
should not echo newline char while reading stdin

### DIFF
--- a/rmate
+++ b/rmate
@@ -361,9 +361,9 @@ elif [ "$filepath" = "-" ]; then
     fi
 
     data=$(cat)
-    filesize=$(echo -e "$data" | wc -c)
+    filesize=$(echo -ne "$data" | wc -c)
     echo "data: $filesize" 1>&3
-    echo "$data" 1>&3
+    echo -n "$data" 1>&3
 else
     echo "data: 0" 1>&3
 fi

--- a/rmate
+++ b/rmate
@@ -360,7 +360,9 @@ elif [ "$filepath" = "-" ]; then
         log "Reading from stdin"
     fi
 
-    data=$(cat)
+    # preserve trailing newlines
+    data=`cat; echo x`
+    data=${data%x}
     filesize=$(echo -ne "$data" | wc -c)
     echo "data: $filesize" 1>&3
     echo -n "$data" 1>&3


### PR DESCRIPTION
It will suppress the auto newline char and preserve existing empty lines while reading stdin.