### PR TITLE
Set custom rsub-port via logged in user

### DIFF
--- a/rmate
+++ b/rmate
@@ -56,7 +56,11 @@ hostname=$($(hostname_command))
 
 # default configuration
 host=localhost
-port=52698
+if [ -f "$(getent passwd "$(logname)" | cut -d: -f6)/.rsub" ];then
+  port="$(cat $(getent passwd "$(logname)" | cut -d: -f6)/.rsub |grep '^port'|cut -d '=' -f2|tr -d '[:space:]')"
+else
+  port=52698
+fi
 
 function load_config {
     local rc_file=$1


### PR DESCRIPTION
When using rsub in multiuser-environmets. setting a custom port via
environment-variables won’t work if you use sudo. This patch let’s you
set a .rsub config-file in your homedir witht the following content:

port=52697

the .rsub-file can be eg. distributed by puppet for making things
easier.

The same port should then be set in your .ssh/config file as:
Host *
RemoteForward 52697 127.0.0.1:52698