### PR TITLE
resolve array issues reported by shellcheck 

### DIFF
--- a/rmate
+++ b/rmate
@@ -209,7 +209,7 @@ fi
 
 filepaths=("$@")
 
-if [ "${filepaths[@]}" = "" ]; then
+if [ "${filepaths[*]}" = "" ]; then
     if [[ $nowait = false ]]; then
         filepaths=('-')
     else

--- a/rmate
+++ b/rmate
@@ -209,9 +209,9 @@ fi
 
 filepaths=("$@")
 
-if [ "$filepaths" = "" ]; then
+if [ "${filepaths[@]}" = "" ]; then
     if [[ $nowait = false ]]; then
-        filepaths='-'
+        filepaths=('-')
     else
         case "$-" in
             *i*)
@@ -219,7 +219,7 @@ if [ "$filepaths" = "" ]; then
                 exit 1
                 ;;
             *)
-                filepaths='-'
+                filepaths=('-')
                 ;;
         esac
     fi


### PR DESCRIPTION
`shellcheck` utility identified 3 issues relating to use of arrays in rmate. This PR attempts to resolve them. Proposed resolution is a `"$filepaths[*]"` array expansion in the first case and use of array assignment `filepaths=('-')` for the second 2 cases.

The snippet below shows the issues as reported by shellcheck v 0.4.6.

````bash
shellcheck rmate | grep -E -B 4 'SC21[27]8'

In rmate line 212:
if [ "$filepaths" = "" ]; then
      ^-- SC2128: Expanding an array without an index only gives the first element.
--
In rmate line 214:
        filepaths='-'
        ^-- SC2178: Variable was used as an array but is now assigned a string.
--
In rmate line 222:
                filepaths='-'
                ^-- SC2178: Variable was used as an array but is now assigned a string.
````
