### PR TITLE
resolve shellcheck SC2162: read without -r will mangle backslashes

### DIFF
--- a/rmate
+++ b/rmate
@@ -67,7 +67,7 @@ function load_config {
     local port_pattern="^port(:[[:space:]]+|=)([0-9]+)"
 
     if [ -f "$rc_file" ]; then
-        while read row; do
+        while read -r row; do
             if [[ "$row" =~ $host_pattern ]]; then
                 host=${BASH_REMATCH[2]}
             elif [[ "$row" =~ $port_pattern ]]; then
@@ -313,7 +313,7 @@ function handle_connection {
     local token
     local tmp
 
-    while read 0<&3; do
+    while read -r 0<&3; do
         REPLY="${REPLY#"${REPLY%%[![:space:]]*}"}"
         REPLY="${REPLY%"${REPLY##*[![:space:]]}"}"
 
@@ -322,7 +322,7 @@ function handle_connection {
         token=""
         tmp=""
 
-        while read 0<&3; do
+        while read -r 0<&3; do
             REPLY="${REPLY#"${REPLY%%[![:space:]]*}"}"
             REPLY="${REPLY%"${REPLY##*[![:space:]]}"}"
 
@@ -379,7 +379,7 @@ if [ $? -gt 0 ]; then
     exit 1
 fi
 
-read server_info 0<&3
+read -r server_info 0<&3
 
 log $server_info
 


### PR DESCRIPTION
Though it seems unlikely something like "hostname" would have backslash-escaped characters, shellcheck warns that rmate uses "read without -r" in 3 places. This PR includes the recommended change in all 4 places.

Note that `$ help read` indicates:
> If the -r option is given, this signifies `raw' input, and
> backslash escaping is disabled.

The `read -r` option might _not_ be what `rmate` needs, in any (or all) cases.

The snippet below shows the issues as reported by shellcheck v 0.4.6.

````bash
shellcheck rmate | grep -F -B 4 'SC2162'

In rmate line 70:
        while read row; do
              ^-- SC2162: read without -r will mangle backslashes.
--
In rmate line 316:
    while read 0<&3; do
          ^-- SC2162: read without -r will mangle backslashes.
--
In rmate line 325:
        while read 0<&3; do
              ^-- SC2162: read without -r will mangle backslashes.
--
In rmate line 382:
read server_info 0<&3
^-- SC2162: read without -r will mangle backslashes.
````
