### PR TITLE
Fix for issue #57 and improvements in file handling

### DIFF
--- a/rmate
+++ b/rmate
@@ -128,6 +128,11 @@ function dirpath {
 
 function canonicalize {
     filepath="$1"
+
+   if [[ "${filepath:0:1}" = "-" ]]; then
+       filepath="./$filepath"
+   fi
+
     dir=`dirpath "$filepath"`
     if [ -L "$filepath" ]; then
         relativepath=`cd "$dir"; readlink \`basename "$filepath"\``

--- a/rmate
+++ b/rmate
@@ -148,6 +148,10 @@ while [[ "${1:0:1}" = "-" || "$1" =~ ^\+([0-9]+)$ ]]; do
         -)
             break
             ;;
+        --)
+            shift
+            break
+            ;;
         -H|--host)
             host=$2
             shift

--- a/rmate
+++ b/rmate
@@ -123,7 +123,7 @@ function log {
 }
 
 function dirpath {
-    (cd `dirname $1` >/dev/null 2>/dev/null; pwd -P)
+    (cd `dirname "$1"` >/dev/null 2>/dev/null; pwd -P)
 }
 
 function canonicalize {


### PR DESCRIPTION
Fix for #57, fixed an issue with files including whitespace character, added (better) support for files with leading leading dash (eg.: `-foo`).