### PR TITLE
quote directory names & warn if cd fails

### DIFF
--- a/rmate
+++ b/rmate
@@ -127,7 +127,7 @@ function log {
 }
 
 function dirpath {
-    (cd `dirname "$1"` >/dev/null 2>/dev/null; pwd -P)
+    (cd "`dirname "$1"`" >/dev/null 2>/dev/null || { echo "unable to cd to $1 directory" 1>&2; exit; } ; pwd -P)
 }
 
 function canonicalize {
@@ -139,7 +139,7 @@ function canonicalize {
 
     dir=`dirpath "$filepath"`
     if [ -L "$filepath" ]; then
-        relativepath=`cd "$dir"; readlink \`basename "$filepath"\``
+        relativepath=`cd "$dir" || { echo "unable to cd to $dir" 1>&2; exit; } ; readlink "\`basename "$filepath"\`"`
         result=`dirpath "$relativepath"`/`basename "$relativepath"`
     else
         result=`basename "$filepath"`

--- a/rmate
+++ b/rmate
@@ -57,7 +57,7 @@ hostname=$($(hostname_command))
 # default configuration
 host=localhost
 port=52698
-eval home=$(builtin printf "~%q" "${SUDO_USER:-$LOGNAME}")
+eval home="$(builtin printf "~%q" "${SUDO_USER:-$LOGNAME}")"
 
 function load_config {
     local rc_file=$1
@@ -78,7 +78,7 @@ function load_config {
 }
 
 for i in "/etc/${0##*/}" $home/."${0##*/}/${0##*/}.rc" $home/."${0##*/}.rc"; do
-    load_config $i
+    load_config "$i"
 done
 
 host="${RMATE_HOST:-$host}"
@@ -97,8 +97,8 @@ force=false
 # process command-line parameters
 #
 function showusage {
-    echo "usage: $(basename $0) [arguments] file-path  edit specified file
-   or: $(basename $0) [arguments] -          read text from stdin
+    echo "usage: $(basename "$0") [arguments] file-path  edit specified file
+   or: $(basename "$0") [arguments] -          read text from stdin
 
 -H, --host HOST  Connect to HOST. Use 'auto' to detect the host from
                  SSH. Defaults to $host.
@@ -123,24 +123,24 @@ function log {
 }
 
 function dirpath {
-    (cd `dirname $1` >/dev/null 2>/dev/null; pwd -P)
+    (cd `dirname "$1"` >/dev/null 2>/dev/null; pwd -P)
 }
 
 function canonicalize {
     filepath="$1"
     dir=`dirpath "$filepath"`
     if [ -L "$filepath" ]; then
-        relativepath=`cd "$dir"; readlink \`basename "$filepath"\``
+        relativepath=`cd "$dir"; readlink "\`basename "$filepath"\`"`
         result=`dirpath "$relativepath"`/`basename "$relativepath"`
     else
-        result=`basename "$filepath"`
+        result="`basename "$filepath"`"
         if [ "$dir" = '/' ]; then
             result="$dir$result"
         else
             result="$dir/$result"
         fi
     fi
-    echo $result
+    echo "$result"
 }
 
 while [[ "${1:0:1}" = "-" || "$1" =~ ^\+([0-9]+)$ ]]; do
@@ -184,7 +184,7 @@ while [[ "${1:0:1}" = "-" || "$1" =~ ^\+([0-9]+)$ ]]; do
             verbose=true
             ;;
         --version)
-            echo $version_string
+            echo "$version_string"
             exit 1
             ;;
         -h|-\?|--help)
@@ -240,7 +240,7 @@ function open_file {
 
     if [ "$filepath" != "-" ]; then
         realpath=`canonicalize "$filepath"`
-        log $realpath
+        log "$realpath"
 
         if [ -d "$filepath" ]; then
             echo "$filepath is a directory and rmate is unable to handle directories."
@@ -344,7 +344,7 @@ function handle_connection {
                         touch "$tmp"
                     fi
 
-                    dd bs=1 count=$value <&3 >>"$tmp" 2>/dev/null
+                    dd bs=1 count="$value" <&3 >>"$tmp" 2>/dev/null
                     ;;
                 *)
                     ;;
@@ -372,7 +372,7 @@ function handle_connection {
 
 # connect to textmate and send command
 #
-exec 3<> /dev/tcp/$host/$port
+exec 3<> "/dev/tcp/$host/$port"
 
 if [ $? -gt 0 ]; then
     echo "Unable to connect to TextMate on $host:$port"
@@ -381,7 +381,7 @@ fi
 
 read server_info 0<&3
 
-log $server_info
+log "$server_info"
 
 for i in "${!filepaths[@]}"; do
     open_file "$i"

--- a/rmate
+++ b/rmate
@@ -52,14 +52,12 @@ function hostname_command(){
     fi
 }
 
-# intent is to execute hostname command, so disable the warning
-# shellcheck disable=SC2091
 hostname=$($(hostname_command))
 
 # default configuration
 host=localhost
 port=52698
-eval home="$(builtin printf "~%q" "${SUDO_USER:-$LOGNAME}")"
+eval home=$(builtin printf "~%q" "${SUDO_USER:-$LOGNAME}")
 
 function load_config {
     local rc_file=$1
@@ -79,10 +77,8 @@ function load_config {
     fi
 }
 
-# "home" is from earlier eval so disable warning about unassigned reference
-# shellcheck disable=SC2154
 for i in "/etc/${0##*/}" $home/."${0##*/}/${0##*/}.rc" $home/."${0##*/}.rc"; do
-    load_config "$i"
+    load_config $i
 done
 
 host="${RMATE_HOST:-$host}"
@@ -101,8 +97,8 @@ force=false
 # process command-line parameters
 #
 function showusage {
-    echo "usage: $(basename "$0") [arguments] file-path  edit specified file
-   or: $(basename "$0") [arguments] -          read text from stdin
+    echo "usage: $(basename $0) [arguments] file-path  edit specified file
+   or: $(basename $0) [arguments] -          read text from stdin
 
 -H, --host HOST  Connect to HOST. Use 'auto' to detect the host from
                  SSH. Defaults to $host.
@@ -296,8 +292,6 @@ function open_file {
     fi
 
     if [ "$filepath" != "-" ] && [ -f "$filepath" ]; then
-        # ls is used to get filesize, so skip warning about find
-        # shellcheck disable=SC2012
         filesize=`ls -lLn "$realpath" | awk '{print $5}'`
         echo "data: $filesize" 1>&3
         cat "$realpath" 1>&3
@@ -389,8 +383,6 @@ function handle_connection {
 #
 exec 3<> /dev/tcp/$host/$port
 
-# checking return value of exec here is clearer; skip warning
-# shellcheck disable=SC2181
 if [ $? -gt 0 ]; then
     echo "Unable to connect to TextMate on $host:$port"
     exit 1

--- a/rmate
+++ b/rmate
@@ -131,7 +131,7 @@ function canonicalize {
     dir="$(dirpath "$filepath")"
     if [ -L "$filepath" ]; then
         relativepath="$(cd "$dir" || { echo "unable to cd to $dir" 1>&2; exit; } ; readlink "$(basename "$filepath")")"
-        result=`dirpath "$relativepath"`/`basename "$relativepath"`
+        result="$(dirpath "$relativepath/$(basename "$relativepath")")"
     else
         result="$(basename "$filepath")"
         if [ "$dir" = '/' ]; then

--- a/rmate
+++ b/rmate
@@ -52,6 +52,8 @@ function hostname_command(){
     fi
 }
 
+# intent is to execute hostname command, so disable the warning
+# shellcheck disable=SC2091
 hostname=$($(hostname_command))
 
 # default configuration
@@ -77,6 +79,8 @@ function load_config {
     fi
 }
 
+# "home" is from earlier eval so disable warning about unassigned reference
+# shellcheck disable=SC2154
 for i in "/etc/${0##*/}" $home/."${0##*/}/${0##*/}.rc" $home/."${0##*/}.rc"; do
     load_config "$i"
 done
@@ -283,6 +287,8 @@ function open_file {
     fi
 
     if [ "$filepath" != "-" ] && [ -f "$filepath" ]; then
+        # ls is used to get filesize, so skip warning about find
+        # shellcheck disable=SC2012
         filesize="$(ls -lLn "$realpath" | awk '{print $5}')"
         echo "data: $filesize" 1>&3
         cat "$realpath" 1>&3
@@ -374,6 +380,8 @@ function handle_connection {
 #
 exec 3<> "/dev/tcp/$host/$port"
 
+# checking return value of exec here is clearer; skip warning
+# shellcheck disable=SC2181
 if [ $? -gt 0 ]; then
     echo "Unable to connect to TextMate on $host:$port"
     exit 1

--- a/rmate
+++ b/rmate
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # rmate
-# Copyright (C) 2011-2016 by Harald Lapp <harald@octris.org>
+# Copyright (C) 2011-2017 by Harald Lapp <harald@octris.org>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -33,8 +33,8 @@
 
 # init
 #
-version="0.9.8"
-version_date="2016-04-14"
+version="0.9.9"
+version_date="2017-04-06"
 version_string="rmate-sh $version ($version_date)"
 
 # determine hostname


### PR DESCRIPTION
Handles some edge cases where directory name or base name might have spaces, file globs, etc.

Also exits with a error message to STDERR if a `cd` command fails.