### PR TITLE
Don't return error (1) when showing version / help

### DIFF
--- a/rmate
+++ b/rmate
@@ -198,11 +198,11 @@ while [[ "${1:0:1}" = "-" || "$1" =~ ^\+([0-9]+)$ ]]; do
             ;;
         --version)
             echo "$version_string"
-            exit 1
+            exit 0
             ;;
         -h|-\?|--help)
             showusage
-            exit 1
+            exit 0
             ;;
         +[0-9]*)
             selections+=(${1:1})


### PR DESCRIPTION
I'm trying to package rmate-sh for homebrew and I test the correct installation of it by running `mate --version`. This returns `1` however, which homebrew's test assertion considers an error (which is standard). This pr makes it return the expected 0 instead since no errors happened ☺️ .
