### PR TITLE
Use $TMPDIR instead of /tmp

### DIFF
--- a/rmate
+++ b/rmate
@@ -84,6 +84,7 @@ done
 host="${RMATE_HOST:-$host}"
 port="${RMATE_PORT:-$port}"
 
+tmp_dir="${TMPDIR:-/tmp}"
 
 # misc initialization
 filepaths=()
@@ -376,7 +377,7 @@ function handle_connection {
                     ;;
                 "data")
                     if [ "$tmp" = "" ]; then
-                        tmp="/tmp/rmate.$RANDOM.$$"
+                        tmp="$tmp_dir/rmate.$RANDOM.$$"
                         touch "$tmp"
                     fi
 


### PR DESCRIPTION
Hey there,

I've tried to use `rmate` on [Termux](https://termux.com/) (Terminal Emulator for Android) but I ran into the problem that the `/tmp` folder is not writable for the default user (not using a rooted phone). However `$TMPDIR` is set and appears to be the default environment variable to hold the name of the system's temporary directory. That said, I modified the code to use that and - if not set - fall back to `/tmp`.

Hope that's okay. :)