### PR TITLE
Fix global settings file path

### DIFF
--- a/rmate
+++ b/rmate
@@ -77,7 +77,7 @@ function load_config {
     fi
 }
 
-for i in "/etc/${0##*/}" $home/."${0##*/}/${0##*/}.rc" $home/."${0##*/}.rc"; do
+for i in "/etc/${0##*/}.rc" $home/."${0##*/}/${0##*/}.rc" $home/."${0##*/}.rc"; do
     load_config $i
 done
 


### PR DESCRIPTION
Now the path is the same as documented: `/etc/rmate.rc`.
Originally, the script searched `/etc/rmate`.