### PR TITLE
Use standard variable names to specify installation location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 BIN ?= rmate
 PREFIX ?= /usr/local
+prefix ?= $(PREFIX)
+exec_prefix ?= $(prefix)
+bindir ?= $(exec_prefix)/bin
 
 install:
-	cp rmate $(PREFIX)/bin/$(BIN)
+	cp rmate $(bindir)/$(BIN)
 
 uninstall:
-	rm -f $(PREFIX)/bin/$(BIN)
+	rm -f $(bindir)/$(BIN)
 
 .PHONY: install uninstall


### PR DESCRIPTION
I added several variables at the top of the make file so that standard options can be used to specify installation location. This way it's not hard-coded to prefix/bin. For example, prefix might be ~ or ~/.local but I may want to install in ~/Tools.

Variable names are case-sensitive so keep existing PREFIX and add lowercase prefix. bindir is conventionally $(exec_prefix)/bin so add exec_prefix and then finally bindir.