### PR TITLE
rmate[.sh]: Quoting -m / -l args

### DIFF
--- a/rmate
+++ b/rmate
@@ -194,11 +194,11 @@ while [[ "$1" != "" ]]; do
             nowait=true
             ;;
         -l|--line)
-            selections+=($2)
+            selections+=("$2")
             shift
             ;;
         -m|--name)
-            displaynames+=($2)
+            displaynames+=("$2")
             shift
             ;;
         -t|--type)


### PR DESCRIPTION
Quote each argument from -m "display name", and -l "line":

  * `-m` -- I noticed this issue because I wrote a bash wrapper function around rmate to prefix '@ ' on every display name.  ...So that I could easily determine which buffers were stale & needed closing after opening the laptop and getting the Sublime Text 4 (w/ plugin RemoteSubl) error that a remote file was closed -- but *not* indicating which one it was.
  * `-l` -- ...then I looked for other arg strings that could also be affected in the same way. According to the Macromates blog post https://macromates.com/blog/2011/mate-and-rmate/ TextMate 2's `-l` param can now be complicated strings that specify multiple selection
    areas (f/ex: `2:18-2:21&3:1-3:4&4:18x5:21&4:30x5:33`)